### PR TITLE
issue : not launched and parse no systemd propterties

### DIFF
--- a/src/nhm-helper.c
+++ b/src/nhm-helper.c
@@ -78,3 +78,22 @@ nhm_helper_str_in_strv(const gchar *str,
 
   return retval;
 }
+
+gboolean nhm_helper_str_in_GVariant(const gchar* str,
+                GVariant* var) {
+  gboolean retval = FALSE;
+
+  GVariantIter iter;
+  gchar *item;
+  GVariant *value;
+
+  g_variant_iter_init(&iter, var);
+  while ( g_variant_iter_loop(&iter, "{sv}", &item, &value) ) {    
+    if ( g_strcmp0(str, item) == 0 ) {
+      retval = TRUE;
+      break;
+    }
+  }
+
+  return retval;
+}

--- a/src/nhm-helper.h
+++ b/src/nhm-helper.h
@@ -41,5 +41,8 @@ DLT_IMPORT_CONTEXT(nhm_helper_trace_ctx);
 gboolean nhm_helper_str_in_strv(const gchar *str,
                                 gchar       *strv[]);
 
+/* Parse systemd service values, added by HMC */
+gboolean nhm_helper_str_in_GVariant(const gchar* str,
+								GVariant* var);
 
 #endif /* NHM_HELPER_H */


### PR DESCRIPTION
  - node-health-monitor is not launched.
  - node-health-monitor don't parse ActiveState property of systemd, which indicates service's state.
fix :
  - the routine to adopt path info is modified in nhm_systemd_unit_added.
  - the method for Adopting ActiveState item from systemd service properies is added.
  - the parser is added to the logic.

Signed-off-by: Daebong An/Senior Engineer/Hyundai motor Company <daebongan@hyundai.com>